### PR TITLE
Add builder based configurability

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@ pub enum GitVersionFormat {
 	Fancy,
 	
 	/// Uses always the long format:
-	/// ```
+	/// ```ignore
 	/// format!("{}-{}-g{}", tag_name, commits_ahead, commit_hash)
 	/// ```
 	///
@@ -107,7 +107,7 @@ pub enum GitVersionFormat {
 ///
 /// A minimal usage version is `GitVersion::new().set_env()`
 ///
-#[derive(Clone,Debug)]
+#[derive(Clone,Debug,Hash,PartialEq,Eq)]
 pub struct GitVersion {
 	/// The name of the environment variable to be set.
 	env_var_name: String,
@@ -148,8 +148,11 @@ impl GitVersion {
 	/// `new` returns an initialized `GitVersion`.
 	/// The initialization has the same effect as the following pseudo code:
 	/// ```
-	/// let gv: GitVersion;
-	/// ...
+	/// # use git_version::GitVersion;
+	/// # use git_version::GitVersionFormat;
+	/// let mut gv: GitVersion;
+	/// // ...
+	/// # gv = GitVersion::new();
 	/// gv.env_var_name("VERSION".to_string())
 	///   .dirty_suffix(Some("-modified".to_string()))
 	///   .broken_suffix(Some("-broken".to_string()))
@@ -160,6 +163,7 @@ impl GitVersion {
 	///   .contains(false)
 	///   .first_parent(false)
 	///   .all_refs(false)
+	/// # ;assert_eq!(gv, GitVersion::new());
 	/// ```
 	/// Hence, the default configuration would set the environment variable name
 	/// `VERSION`, adds the suffix `-modified` or `-broken` if the working tree
@@ -232,7 +236,7 @@ impl GitVersion {
 	/// If `len` is `0`, the default hash length is used.
 	///
 	/// `hash_length` is analogous to the `--abbrev` option of `git describe`,
-	/// but differs in special cases, see next [section][#Compatibility].
+	/// but differs in special cases, see next section.
 	///
 	/// # Compatibility
 	///
@@ -261,7 +265,7 @@ impl GitVersion {
 	/// This could be useful when using
 	/// [`try_set_env`][GitVersion::try_set_env()],
 	/// which returns `Err(_)` if `number` is `0` and HEAD is not tagged.
-	/// This could be further used to implement spacial handling in `build.rs`.
+	/// This could be further used to implement special handling in `build.rs`.
 	///
 	/// `candidates` is analogous to the `--candidates` option of
 	/// `git describe`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@
 //! So you must have `git` installed somewhere in your `PATH`.
 
 use std::process::Command;
+use std::io::Result;
 
 /// Instruct cargo to set the VERSION environment variable to the version as
 /// indicated by `git describe --tags --always --dirty=-modified`.
@@ -23,7 +24,8 @@ use std::process::Command;
 /// Also instructs cargo to *always* re-run the build script and recompile the
 /// code, to make sure the version number is always correct.
 pub fn set_env() {
-	set_env_with_name("VERSION");
+	GitVersion::new()
+		.set_env()
 }
 
 /// Same as `set_env`, but using `name` as environment variable.
@@ -36,13 +38,9 @@ pub fn set_env() {
 /// fn main() { git_version::set_env_with_name("CARGO_PKG_VERSION"); }
 /// ```
 pub fn set_env_with_name(name: &str) {
-	if let Err(e) = try_set_env_with_name(name) {
-		// Catch general error
-		eprintln!("[git-version] Error: {}", e);
-		
-		println!("cargo:rustc-env={}={}", name, "undetermined");
-		println!("cargo:rerun-if-changed=(nonexistentfile)");
-	}
+	GitVersion::new()
+		.env_var_name(name.to_string())
+		.set_env()
 }
 
 /// Same as `set_env_with_name`, but with explicit feedback about success and
@@ -53,24 +51,112 @@ pub fn set_env_with_name(name: &str) {
 /// named `name` to is set to the version as
 /// indicated by `git describe --tags --always --dirty=-modified`.
 ///
-pub fn try_set_env_with_name(name: &str) -> std::io::Result<()> {
-	let cmd = Command::new("git").args(
-		&["describe", "--always", "--tags", "--dirty=-modified"]).output()?;
-	
-	if !cmd.status.success() {
-		return Err(std::io::Error::new(
-			std::io::ErrorKind::Other,
-			format!("Git failed to describe HEAD, return code: {:?}\n{}",
-				cmd.status.code(),
-				String::from_utf8_lossy(&cmd.stderr)
-			)
-		));
+pub fn try_set_env_with_name(name: &str) -> Result<()> {
+	GitVersion::new()
+		.env_var_name(name.to_string())
+		.try_set_env()
+}
+
+
+/// Notice: the combination of hash_length == 0 and long_format == true is illegal
+pub struct GitVersion {
+	hash_length: Option<usize>,
+	dirty_suffix: Option<String>,
+	broken_suffix: Option<String>,
+	env_var_name: String,
+	long_format: bool,
+	unannotated_tags: bool,
+	contains_tags: bool,
+}
+
+impl GitVersion {
+	pub fn new() -> Self {
+		GitVersion {
+			hash_length: None,
+			dirty_suffix: Some("-modified".to_string()),
+			broken_suffix: None,
+			env_var_name: "VERSION".to_string(),
+			long_format: false,
+			unannotated_tags: true,
+			contains_tags: false,
+		}
 	}
 	
-	let ver = String::from_utf8_lossy(&cmd.stdout);
+	pub fn hash_length(&mut self, len: Option<usize>) -> &mut Self {
+		self.hash_length = len;
+		
+		self
+	}
 	
-	println!("cargo:rustc-env={}={}", name, ver);
-	println!("cargo:rerun-if-changed=(nonexistentfile)");
+	pub fn env_var_name(&mut self, name: String) -> &mut Self {
+		self.env_var_name = name;
+		
+		self
+	}
 	
-	Ok(())
+	// TODO add further confs
+	
+	pub fn set_env(&self) {
+		self.set_env_with_default("undetermined");
+	}
+	
+	pub fn set_env_with_default(&self, default_tag: &str) {
+		if let Err(e) = self.try_set_env() {
+			// Catch general error
+			eprintln!("[git-version] Error: {}", e);
+			
+			println!("cargo:rustc-env={}={}", self.env_var_name, default_tag);
+			println!("cargo:rerun-if-changed=(nonexistentfile)");
+		}
+	}
+	
+	///
+	/// Try to set the environment variable.
+	///
+	/// # Panic
+	///
+	/// This function panics if `hash_length(Some(0))` and `long_format(true)` have
+	/// been both specified.
+	/// This is because `git` rejects this specific combination:
+	/// ```
+	/// fatal: --long is incompatible with --abbrev=0
+	/// ```
+	/// Consequently, this combination of option values must never be configured
+	/// in the first place and is considered a programming error.
+	///
+	/// Notice, that this panic would render your project unable to been build.
+	///
+	///
+	pub fn try_set_env(&self) -> Result<()> {
+		// Notice a violation of this assertion is an programmatic error,
+		// which shall be indicated by a panic, to be fixed by the programmer.
+		// Otherwise, `git` would fail and potentially it would be handled
+		// silently by the 'undetermined' tag.
+		assert!(!(self.hash_length == Some(0) && self.long_format));
+		
+		// TODO implement using the config of self
+		let cmd = Command::new("git").args(
+		&["describe", "--always", "--tags", "--dirty=-modified"]).output()?;
+		
+		if !cmd.status.success() {
+			return Err(std::io::Error::new(
+				std::io::ErrorKind::Other,
+				format!("Git failed to describe HEAD, return code: {:?}\n{}",
+					cmd.status.code(),
+					String::from_utf8_lossy(&cmd.stderr)
+				)
+			));
+		}
+		
+		let ver = String::from_utf8_lossy(&cmd.stdout);
+		
+		println!("cargo:rustc-env={}={}", self.env_var_name, ver);
+		println!("cargo:rerun-if-changed=(nonexistentfile)");
+		
+		Ok(())
+	}
 }
+
+
+
+


### PR DESCRIPTION
Add a struct, which allows builder-patter like to configure the content of the environment variable.
It is oriented on the `git describe` feature set.