### PR TITLE
enable proc-macro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target/
 **/*.rs.bk
 Cargo.lock
+*~

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,3 @@
-[package]
-name = "git-version"
-description = "Compile the git version (tag name, or hash otherwise) and dirty state into your program."
-version = "0.2.1"
-authors = ["Mara Bos <m-ou.se@m-ou.se>"]
-license = "BSD-2-Clause"
-repository = "https://github.com/m-ou-se/rust-git-version"
-documentation = "https://docs.rs/git-version/"
-keywords = ["git", "version", "build"]
-categories = ["development-tools", "development-tools::build-utils"]
-edition = "2018"
+[workspace]
+
+members = ["git-version", "git-version-macro"]

--- a/git-version-macro/Cargo.toml
+++ b/git-version-macro/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "git-version-macro"
+version = "0.0.1"
+authors = ["David Roundy <daveroundy@gmail.com>"]
+edition = "2018"
+description = "Internal macro crate for git-version."
+repository = "https://github.com/m-ou-se/rust-git-version"
+keywords = ["git"]
+license = "BSD-2-Clause"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "0.6"
+proc-macro2 = "0.4.24"
+proc-macro-hack = "0.5"

--- a/git-version-macro/src/lib.rs
+++ b/git-version-macro/src/lib.rs
@@ -1,0 +1,96 @@
+extern crate proc_macro;
+
+use proc_macro::{ TokenStream };
+use quote::{ quote };
+use std::path::Path;
+use proc_macro_hack::proc_macro_hack;
+
+#[proc_macro]
+pub fn declare(input: TokenStream) -> TokenStream {
+    let identifier = proc_macro2::TokenStream::from(input);
+    let cwd = std::env::current_dir().unwrap();
+    let head = cwd.join(".git/HEAD").to_str().unwrap().to_string();
+    let mut interesting_files = vec![head];
+    let refs = Path::new(".git/refs/heads");
+    for entry in refs.read_dir().expect("read_dir call failed") {
+        if let Ok(entry) = entry {
+            interesting_files.push(cwd.join(entry.path()).to_str().unwrap().to_string());
+        }
+    }
+    let vec = std::process::Command::new("git")
+            .args(&["describe", "--always", "--dirty"])
+            .output()
+        .expect("failed to execute git").stdout;
+    let name = std::str::from_utf8(&vec[..vec.len()-1]).expect("non-utf8 error?!");
+    let x = quote!{
+        fn __unused_by_git_version() {
+            // This is included simply to cause cargo to rebuild when
+            // a new commit is made.
+            #( include_str!(#interesting_files); )*
+        }
+        const #identifier: &'static str = {
+            #name
+        };
+    };
+    // println!("tokens are {}", x);
+    x.into()
+}
+
+/// Use the given template to create a string.
+///
+/// You can think of this as being kind of like `format!` on strange drugs.
+#[proc_macro_hack]
+pub fn git_describe(input: TokenStream) -> TokenStream {
+    let mut args = Vec::new();
+    let mut next_arg = String::new();
+    for t in input.into_iter() {
+        let x = t.to_string();
+        let last_char = next_arg.clone().pop(); // yes, this is terribly wasteful...
+        if next_arg.len() > 0 && next_arg != "-" && next_arg != "--" && x == "-"
+            && last_char != Some('=')
+        {
+            args.push(next_arg.clone());
+            next_arg = String::new();
+        }
+        next_arg.extend(x.chars());
+    }
+    if next_arg.len() > 0 {
+        args.push(next_arg);
+    }
+    let cwd = std::env::current_dir().unwrap();
+    let head = cwd.join(".git/HEAD").to_str().unwrap().to_string();
+    let mut interesting_files = vec![head];
+    let refs = Path::new(".git/refs/heads");
+    for entry in refs.read_dir().expect("read_dir call failed") {
+        if let Ok(entry) = entry {
+            interesting_files.push(cwd.join(entry.path()).to_str().unwrap().to_string());
+        }
+    }
+    let mut cmd = std::process::Command::new("git");
+    cmd.args(&["describe", "--always"]);
+    for a in args.iter() {
+        cmd.arg(&a);
+    }
+    let vec = cmd.output().expect("failed to execute git").stdout;
+    if vec.len() == 0 {
+        panic!("the command {:?} exited without returning a description", cmd);
+    }
+    let name = std::str::from_utf8(&vec[..vec.len()-1]).expect("non-utf8 error?!");
+    let x = quote!{
+        {
+            // This is included simply to cause cargo to rebuild when
+            // a new commit is made.
+            #( include_str!(#interesting_files); )*
+            #name
+        }
+    };
+    x.into()
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/git-version/Cargo.toml
+++ b/git-version/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "git-version"
+description = "Compile the git version (tag name, or hash otherwise) and dirty state into your program."
+version = "0.3.0"
+authors = ["Mara Bos <m-ou.se@m-ou.se>"]
+license = "BSD-2-Clause"
+repository = "https://github.com/m-ou-se/rust-git-version"
+documentation = "https://docs.rs/git-version/"
+keywords = ["git", "version", "build"]
+categories = ["development-tools", "development-tools::build-utils"]
+edition = "2018"
+
+[dependencies]
+proc-macro-hack = "0.5"
+git-version-macro = { version = "0.0.1", path = "../git-version-macro" }

--- a/git-version/src/lib.rs
+++ b/git-version/src/lib.rs
@@ -15,6 +15,10 @@
 //! So you must have `git` installed somewhere in your `PATH`.
 
 use std::process::{exit, Command, Stdio};
+use proc_macro_hack::proc_macro_hack;
+
+#[proc_macro_hack]
+pub use git_version_macro::git_describe;
 
 /// Instruct cargo to set the VERSION environment variable to the version as
 /// indicated by `git describe --always --dirty=-modified`.

--- a/git-version/tests/version.rs
+++ b/git-version/tests/version.rs
@@ -1,0 +1,13 @@
+use git_version::git_describe;
+
+#[test]
+fn git_describe_is_right() {
+    let vec = std::process::Command::new("git")
+            .args(&["describe", "--always", "--dirty=-modified"])
+            .output()
+        .expect("failed to execute git").stdout;
+    let name = std::str::from_utf8(&vec[..vec.len()-1]).expect("non-utf8 error?!");
+    println!("name = {}", name);
+    println!("GIT_VERSION = {}", git_describe!(--dirty=-modified));
+    assert_eq!(git_describe!(--dirty=-modified), name);
+}

--- a/git-version/tests/version.rs~
+++ b/git-version/tests/version.rs~
@@ -1,0 +1,25 @@
+git_version_macro::declare!(my_version);
+
+#[test]
+fn is_right() {
+    let vec = std::process::Command::new("git")
+            .args(&["describe", "--always", "--dirty"])
+            .output()
+        .expect("failed to execute git").stdout;
+    let name = std::str::from_utf8(&vec[..vec.len()-1]).expect("non-utf8 error?!");
+    assert_eq!(my_version, name);
+}
+
+use git_version_macro::git_describe;
+
+#[test]
+fn git_version_is_right() {
+    let vec = std::process::Command::new("git")
+            .args(&["describe", "--always", "--dirty=-modified"])
+            .output()
+        .expect("failed to execute git").stdout;
+    let name = std::str::from_utf8(&vec[..vec.len()-1]).expect("non-utf8 error?!");
+    println!("name = {}", name);
+    println!("GIT_VERSION = {}", git_describe!(--dirty=-modified));
+    assert_eq!(git_describe!(--dirty=-modified), name);
+}


### PR DESCRIPTION
This pull request creates a proc-macro called git_describe that can be used in expression context to get the version.  I moved the repository to a workspace format to accommodate the extra crate required by proc-macro-hack.

See the git-version/tests/version.rs for a usage example.  The macro takes command line flags as arguments in a pretty hokey way currently, which is sufficient to configure `git describe` and looks sort of pretty.  Part of me things we should just accept a sequence of strings like `git_describe!("--dirty", "--always")` but I was tempted by the cool look of just specifying the flags directly.  Note also that I'm not attached to the name `git_describe!()`.  Somehow I had been thinking that `git_version!()` would conflict with a currently exported symbol, which it doesn't.